### PR TITLE
Fix swagger config and graphql settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test:integration": "jest test -c jest.integration.config.js",
     "test": "npm run test:unit && npm run test:integration",
     "swagger": "swaggerGen -c ./swaggerConfig.json -t",
-    "graphql": "npm run swagger && npx openapi-to-graphql --port=9091 swagger.json --cors"
+    "graphql:run": "npx openapi-to-graphql --port=9091 swagger.json --cors -u http://localhost:9090",
+    "graphql": "npm run swagger && npm run graphql:run"
   },
   "_moduleAliases": {
     "@controllers": "src/controllers",

--- a/swagger.json
+++ b/swagger.json
@@ -476,7 +476,6 @@
 			"in": "query"
 		}
 	},
-	"host": "localhost:9090",
 	"schemes": [
 		"http"
 	]

--- a/swaggerConfig.json
+++ b/swaggerConfig.json
@@ -3,7 +3,6 @@
     "outputDirectory": "./",
     "entryFile": "./src/controllers/*.ts",
     "outputFormat": "openapi_3",
-    "host": "localhost:9090",
     "version": "1.0",
     "name": "Node & GraphQL base starter",
     "description": "Node & GraphQL base starter - description",
@@ -17,7 +16,7 @@
       }
     },
     "spec": {
-      "schemes": ["http"]
+      "schemes": ["http", "https"]
     }
   }
 }


### PR DESCRIPTION
- Fix swagger config to depend on the environment which is deployed.
- Fix graphql commands to pass down the server where the api is hosted.